### PR TITLE
downgraded node-versoin

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node18'
+  using: 'node16'
   main: "dist/index.js"


### PR DESCRIPTION
got error from github running with node18
```
Parameter ''using: node18' is not supported, use 'docker', 'node12' or 'node16
```